### PR TITLE
デプロイしたコントラクトのアドレスとABIをファイルに自動書き込みできるようにコードを更新

### DIFF
--- a/migrations/2_deploy_game_token.js
+++ b/migrations/2_deploy_game_token.js
@@ -1,6 +1,14 @@
 const GameToken = artifacts.require("./GameToken.sol");
+const fs = require('fs')
 
 module.exports = function(deployer) {
   const initialSupply = 10000;
-  deployer.deploy(GameToken, initialSupply);
+  deployer.deploy(GameToken, initialSupply).then(instance => {
+    try {
+      fs.writeFileSync('../game-api/GameToken_address.txt', instance.address);
+      fs.writeFileSync('../game-api/GameToken.abi', JSON.stringify(instance.abi));
+    } catch (err) {
+      console.log(err);
+    }
+  });
 };


### PR DESCRIPTION
## 変更の概要

migrations/2_deploy_game_token.jsにて、fsモジュールを使用して、デプロイしたGameTokenコントラクトのアドレスとABIをgame-api内のGameToken_address.txtとGameToken.abiのファイルに自動で書きこめるようにした。