### PR TITLE
GameTokenにERC20のトークン鋳造機能を追加

### DIFF
--- a/contracts/GameToken.sol
+++ b/contracts/GameToken.sol
@@ -2,9 +2,10 @@
 pragma solidity >=0.4.22 <0.9.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20Burnable.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20Mintable.sol";
 
 //Solidity 0.5
-contract GameToken is ERC20Burnable {
+contract GameToken is ERC20Burnable, ERC20Mintable {
 
   string public name = "GameToken";
   string public symbol = "GT";

--- a/migrations/2_deploy_game_token.js
+++ b/migrations/2_deploy_game_token.js
@@ -1,6 +1,14 @@
 const GameToken = artifacts.require("./GameToken.sol");
+const fs = require('fs')
 
 module.exports = function(deployer) {
   const initialSupply = 10000;
-  deployer.deploy(GameToken, initialSupply);
+  deployer.deploy(GameToken, initialSupply).then(instance => {
+    try {
+      fs.writeFileSync('../game-api/GameToken_address.txt', instance.address);
+      fs.writeFileSync('../game-api/GameToken.abi', JSON.stringify(instance.abi));
+    } catch (err) {
+      console.log(err);
+    }
+  });
 };


### PR DESCRIPTION
## 変更の概要

openzeppelinのERC20からERC20Mintable.solをインポートし、GameTokenコントラクトにERC20Mintableコントラクトを継承させた。これによりトークン鋳造機能がGameTokenに追加された。