### PR TITLE
デプロイしたコントラクトのアドレスとABIをgame-api-gin内のファイルに自動書き込みできるよう更新

### DIFF
--- a/contracts/GameToken.sol
+++ b/contracts/GameToken.sol
@@ -7,11 +7,27 @@ import "@openzeppelin/contracts/token/ERC20/ERC20Mintable.sol";
 //Solidity 0.5
 contract GameToken is ERC20Burnable, ERC20Mintable {
 
-  string public name = "GameToken";
-  string public symbol = "GT";
-  uint public decimals = 0;
+  string private _name;
+  string private _symbol;
+  uint8 private _decimals;
 
-  constructor(uint256 initialSupply) public {
+  constructor(uint256 initialSupply, string memory name, string memory symbol, uint8 decimals) public {
     _mint(msg.sender, initialSupply);
+    _name = name;
+    _symbol = symbol;
+    _decimals = decimals;
   }
+
+  function name() public view returns (string memory) {
+    return _name;
+  }
+
+  function symbol() public view returns (string memory) {
+    return _symbol;
+  }
+
+  function decimals() public view returns (uint8) {
+    return _decimals;
+  }
+
 }

--- a/migrations/2_deploy_game_token.js
+++ b/migrations/2_deploy_game_token.js
@@ -10,6 +10,8 @@ module.exports = function(deployer) {
     try {
       fs.writeFileSync('../game-api/GameToken_address.txt', instance.address);
       fs.writeFileSync('../game-api/GameToken.abi', JSON.stringify(instance.abi));
+      fs.writeFileSync('../game-api-gin/gmtoken/GameToken_address.txt', instance.address);
+      fs.writeFileSync('../game-api-gin/gmtoken/GameToken.abi', JSON.stringify(instance.abi));
     } catch (err) {
       console.log(err);
     }

--- a/migrations/2_deploy_game_token.js
+++ b/migrations/2_deploy_game_token.js
@@ -1,9 +1,12 @@
 const GameToken = artifacts.require("./GameToken.sol");
-const fs = require('fs')
+const fs = require('fs');
 
 module.exports = function(deployer) {
   const initialSupply = 10000;
-  deployer.deploy(GameToken, initialSupply).then(instance => {
+  const name = "GameToken";
+  const symbol = "GT";
+  const decimals = 4;
+  deployer.deploy(GameToken, initialSupply, name, symbol, decimals).then(instance => {
     try {
       fs.writeFileSync('../game-api/GameToken_address.txt', instance.address);
       fs.writeFileSync('../game-api/GameToken.abi', JSON.stringify(instance.abi));


### PR DESCRIPTION
## 変更の概要

migrations/2_deploy_game_token.jsにて、デプロイしたGameTokenコントラクトのアドレスとABIをgame-api-gin/gmtoken内のGameToken_address.txtとGameToken.abiのファイルに自動で書きこめるようにコードを追加した。